### PR TITLE
feat: Improved target file

### DIFF
--- a/src/armv7a-vexos-eabi.json
+++ b/src/armv7a-vexos-eabi.json
@@ -1,11 +1,12 @@
 {
+    "cpu": "cortex-a9",
     "arch": "arm",
     "data-layout": "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "emit-debug-gdb-scripts": false,
     "env": "newlib",
     "executables": true,
-    "features": "+v7,+thumb2,+soft-float,-neon,+strict-align",
+    "features": "+thumb2,+neon,+vfp3",
     "linker": "arm-none-eabi-gcc",
     "linker-flavor": "gcc",
     "llvm-target": "armv7a-none-eabi",
@@ -16,11 +17,12 @@
             "-nostartfiles",
             "-nostdlib",
             "-Wl,-Tv5.ld,-Tv5-common.ld,--gc-sections",
-            "-Wl,--start-group,-lpros,-lc,-lm,-lgcc,-lstdc++,--end-group"
+            "-Wl,--start-group,-lpros,-lc,--end-group"
         ]
     },
     "relocation-model": "static",
     "target-family": "unix",
     "target-pointer-width": "32",
-    "os": "vexos"
+    "os": "vexos",
+    "vendor": "vex"
 }

--- a/src/armv7a-vexos-eabi.json
+++ b/src/armv7a-vexos-eabi.json
@@ -17,7 +17,7 @@
             "-nostartfiles",
             "-nostdlib",
             "-Wl,-Tv5.ld,-Tv5-common.ld,--gc-sections",
-            "-Wl,--start-group,-lpros,-lc,--end-group"
+            "-Wl,--start-group,-lgcc,-lpros,-lc,--end-group"
         ]
     },
     "relocation-model": "static",


### PR DESCRIPTION
- Enables NEON SIMD instructions on armv7a-vexos-eabi
- Provides several feature flags for dealing with floating point operations faster
- Adds some optional but missing data (such as vendor) to the config.
- Specifies -mcpu type as `cortex-a9`
- Removes dependency on `libm` and `libstdc++`. This will cut off ~50kb of binary size from the resulting monolith.
	- This will require `pros-rs` to use a custom `libpros` static library with the C++ parts stripped out. As such, this will depend on https://github.com/pros-rs/pros-rs/pull/81 to get a working build.

Further optimizations may be possible in the future with more research on custom targets.